### PR TITLE
External file save

### DIFF
--- a/src/com/google/android/apps/markers/MarkersActivity.java
+++ b/src/com/google/android/apps/markers/MarkersActivity.java
@@ -39,6 +39,7 @@ import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
 import android.graphics.PixelFormat;
 import android.graphics.Typeface;
 import android.media.MediaScannerConnection;
@@ -838,6 +839,8 @@ public class MarkersActivity extends Activity
         try {
             Bitmap b = MediaStore.Images.Media.getBitmap(getContentResolver(), contentUri);
             if (b != null) {
+                b = checkImageOrientation(b);
+                
                 mSlate.paintBitmap(b);
                 if (DEBUG) Log.d(TAG, "successfully loaded bitmap: " + b);
             } else {
@@ -848,6 +851,35 @@ public class MarkersActivity extends Activity
         } catch (java.io.IOException ex) {
             Log.e(TAG, "error loading image from " + contentUri + ": " + ex);
         }
+    }
+
+    private Bitmap checkImageOrientation( Bitmap b ) {
+        int bWidth = b.getWidth();
+        int bHeight = b.getHeight();
+        int slateWidth = mSlate.getWidth();
+        int slateHeight = mSlate.getHeight();
+        
+        boolean doRotate = false;
+        // insert the bitmap with best fit orientation
+        if (bWidth > bHeight) {
+            // image is landscape
+            if (slateWidth < slateHeight) {
+                // view is portrait, rotate bitmap
+                doRotate = true;
+            }
+        }else{
+            // image is portrait
+            if (slateWidth > slateHeight) {
+                // view is lanscape, rotate bitmap
+                doRotate = true;
+            }
+        }
+        if (doRotate) {
+            Matrix matrix = new Matrix();
+            matrix.postRotate(90);
+            b = Bitmap.createBitmap(b , 0, 0, bWidth, bHeight, matrix, true);
+        }
+        return b;
     }
 
     protected void onActivityResult(int requestCode, int resultCode, Intent imageReturnedIntent) { 

--- a/src/com/google/android/apps/markers/MarkersActivity.java
+++ b/src/com/google/android/apps/markers/MarkersActivity.java
@@ -416,7 +416,7 @@ public class MarkersActivity extends Activity
         try {
             File wipOuputFile = getOuputFile(WIP_FILENAME, true);
             saveDrawing(wipOuputFile, true);
-        } catch (IOException e) {
+        } catch (Exception e) {
             Log.e(TAG, "save: error: " + e);
         }
     }
@@ -469,14 +469,16 @@ public class MarkersActivity extends Activity
         Intent startIntent = getIntent();
         if (DEBUG) Log.d(TAG, "starting with intent=" + startIntent + " extras=" + dumpBundle(startIntent.getExtras()));
         String a = startIntent.getAction();
-        if (a.equals(Intent.ACTION_EDIT)) {
-            // XXX: what happens to the old drawing? we should really move to auto-save
-            mSlate.clear();
-            loadImageFromIntent(startIntent);
-        } else if (a.equals(Intent.ACTION_SEND)) {
-            // XXX: what happens to the old drawing? we should really move to auto-save
-            mSlate.clear();
-            loadImageFromContentUri((Uri)startIntent.getParcelableExtra(Intent.EXTRA_STREAM));
+        if (a != null) {
+            if (a.equals(Intent.ACTION_EDIT)) {
+                // XXX: what happens to the old drawing? we should really move to auto-save
+                mSlate.clear();
+                loadImageFromIntent(startIntent);
+            } else if (a.equals(Intent.ACTION_SEND)) {
+                // XXX: what happens to the old drawing? we should really move to auto-save
+                mSlate.clear();
+                loadImageFromContentUri((Uri) startIntent.getParcelableExtra(Intent.EXTRA_STREAM));
+            }
         }
     }
 


### PR DESCRIPTION
I would like to send in this pull request with 2 commits that:
- checks for the ratio of the loaded image (being it by load or by intent) against the current screen ratio. If necessary, it rotates the bitmap in order to best fit the drawing canvas. 
- adds the possibility to pass through the intent's extra bundle by means of the key _MediaStore.EXTRA_OUTPUT_ (not sure if that is the right choice though) a path to which the image should be saved to when pushing the save button. If that path if supplied, the saving to temporary files is overridden. For that I had to extract the retrieval of the file path into a separate method, to be able to check the case of output path availability.

It would be great to have the possibility to use markers from within a third party application.

Let me know if the request is of interest and if there is something that needs to be changed.
